### PR TITLE
Fix header to be older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,8 +12,6 @@
 <body>
     <div class="container">
         <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
             <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
                 <span class="theme-icon sun-icon">☀️</span>
                 <span class="theme-icon moon-icon">🌙</span>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -69,29 +69,13 @@ body {
 header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     padding: 1rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
     transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -790,9 +774,6 @@ details[open] .suggested-header::before {
         padding: 1rem;
     }
     
-    header h1 {
-        font-size: 1.5rem;
-    }
     
     .chat-messages {
         padding: 1rem;


### PR DESCRIPTION
Fixes #2

Reverted the header to the older version while keeping the theme toggle functionality:

- Removed "Course Materials Assistant" header
- Removed "Ask questions about courses, instructors, and content" subheader
- Removed horizontal line under subheader
- Maintained theme toggle functionality
- Updated header layout for proper positioning

Generated with [Claude Code](https://claude.ai/code)